### PR TITLE
增加 UniFramework.Log

### DIFF
--- a/UniFramework/UniLog.meta
+++ b/UniFramework/UniLog.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4f43b090492030e47a02fe9e01f91bb9
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UniFramework/UniLog/README.md
+++ b/UniFramework/UniLog/README.md
@@ -1,0 +1,42 @@
+# UniFramework.Log
+
+一个轻量级的日志本地存储。
+
+
+
+- 日志每行会自动分割为：[type]	[date]	[log]	at [stack]
+- stack 信息只输出单行位置，定位于日志输出位置
+- 手动执行写入流时，遇到非 *Log*|*Assert* 类型的日志会直接进行流写入，防止崩溃时的数据丢失
+- 打包的软件在运行时会自动压缩日志为zip 格式(可用压缩软件打开阅读)，编辑环境不会
+- 日志文件将以日期(yyyyMMddHHmmss) 命名进行保存，文件大于 **BREAKDISKLENGTH** 将会自动分卷，每次软件运行将会以新时间点穿件日志文件
+- 会自动删除 **MAXRETENTIONDAYS** 天数之外的日志
+
+
+
+#### 范例
+
+```
+public class Boot : MonoBehaviour
+{
+    private void Awake()
+    {
+		//使用默认的启动配置(每次Debug.Log 都会执行写入流操作)，开始存储日志
+        UniLog.Initalize();
+        
+        //或者利用UniLogDriver进行初始化(将会在FixedUpdate 中调用手动 ManualFlush() )
+        //UniLogDriver.Initalize();
+		
+		//或者自动配置参数
+		//UniLog.Instance.SetLogOptions(logEnable,filterLogType,editorCreate,isManualFlush);
+		
+		//在isManualFlush为true时，可手动将执行写入流操作（可在自定的Update 中调用）
+		//UniLog.Instance.ManualFlush();
+    }
+
+    private void OnDestroy()
+    {
+        UniLog.Destroy();
+    }
+}
+```
+

--- a/UniFramework/UniLog/README.md.meta
+++ b/UniFramework/UniLog/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c5f7a9a558cf61d4db68b4fdd548933f
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UniFramework/UniLog/Runtime.meta
+++ b/UniFramework/UniLog/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4eeb379001f82ef4d81ac52d22abb8dd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UniFramework/UniLog/Runtime/UniFramework.Log.asmdef
+++ b/UniFramework/UniLog/Runtime/UniFramework.Log.asmdef
@@ -1,0 +1,3 @@
+{
+	"name": "UniFramework.Log"
+}

--- a/UniFramework/UniLog/Runtime/UniFramework.Log.asmdef.meta
+++ b/UniFramework/UniLog/Runtime/UniFramework.Log.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: a04b92ed98b2cea49befb4b199ef6d98
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UniFramework/UniLog/Runtime/UniLog.cs
+++ b/UniFramework/UniLog/Runtime/UniLog.cs
@@ -1,0 +1,320 @@
+using System;
+using System.IO;
+using UnityEngine;
+using System.Text;
+using System.Diagnostics;
+using System.IO.Compression;
+using Debug = UnityEngine.Debug;
+
+namespace UniFramework.Log
+{
+    public class UniLog
+    {
+        private const string TimeFormat = "HH:mm:ss";
+        private const string TimeFormat2 = "yyyyMMddHHmmss";
+        private const int BREAKDISKLENGTH = 10485760;           //日志文件分卷大小 10M
+#if UNITY_STANDALONE
+        private const int MAXRETENTIONDAYS = 14;                //日志文件的最大保存天数
+#else
+        private const int MAXRETENTIONDAYS = 7;
+#endif
+        private FileStream fileStream;
+        private StreamWriter streamWriter;
+        private StringBuilder sbuilder;
+        private bool _isManualFlush;
+        private bool _isDirty;
+        private int breakDiskCount = 1;                         //当前产生的日志分卷数量
+        private bool isEditorCreate = false;                    //是否在编辑器中也产生日志文件
+
+        public bool IsManualFlush { get => _isManualFlush;set { _isManualFlush = value; } }
+        public GameObject driver;
+
+        #region instance
+        private static bool _isInitialize = false;
+        private static readonly object obj = new object();
+        private static UniLog _instance;
+        public static UniLog Instance
+        {
+            get
+            {
+                if (_instance == null)
+                {
+                    lock (obj)
+                    {
+                        if (_instance == null)
+                        {
+
+                            _instance = new UniLog();
+                            _isInitialize = true;
+                        }
+                    }
+                }
+                return _instance;
+            }
+        }
+        #endregion
+
+        private UniLog()
+        {
+        }
+
+        /// <summary>
+        /// 初始化事件系统
+        /// </summary>
+        public static void Initalize()
+        {
+            if (_isInitialize == false)
+            {
+                _ = Instance;
+                _isInitialize = true;
+
+                Instance.SetLogOptions(true, LogType.Log, true);
+                Instance.StartTrace();
+
+                UniLogger.Log($"{nameof(UniLog)} initalize !");
+            }
+        }
+
+        /// <summary>
+        /// 设置选项
+        /// </summary>
+        /// <param name="logEnable">是否记录日志</param>
+        /// <param name="showFrams">是否显示所有堆栈帧 默认只显示当前帧 如果设为0 则显示所有帧</param>
+        /// <param name="filterLogType">过滤 默认log级别以上</param>
+        /// <param name="editorCreate">是否在编辑器中产生日志记录 默认不需要</param>
+        public void SetLogOptions(bool logEnable, LogType filterLogType = LogType.Log, bool editorCreate = false, bool isManualFlush = false)
+        {
+            Debug.unityLogger.logEnabled = logEnable;
+            Debug.unityLogger.filterLogType = filterLogType;
+            isEditorCreate = editorCreate;
+            _isManualFlush = isManualFlush;
+        }
+
+        /// <summary>
+        /// 开启跟踪日志信息
+        /// </summary>
+        public void StartTrace()
+        {
+            if (!Debug.unityLogger.logEnabled) return;
+
+#if UNITY_EDITOR
+            if (!isEditorCreate) return;
+#endif
+            CreateOutlog();
+
+            Application.logMessageReceivedThreaded += Application_logMessageReceivedThreaded;
+        }
+
+        /// <summary>
+        /// 获取存储目录
+        /// </summary>
+        /// <returns></returns>
+        private string GetDirectory()
+        {
+#if UNITY_STANDALONE || UNITY_EDITOR
+            return Application.dataPath + "/../" + "Logs/UniLog";
+#else
+            return Application.persistentDataPath + "/" + "Logs/UniLog";
+#endif
+        }
+
+        /// <summary>
+        /// 删除过期日志(超出最大的存储限制时长)
+        /// </summary>
+        private void DeleteOldLogFiles()
+        {
+            string[] files = Directory.GetFiles(GetDirectory());
+            DateTime dateTime = DateTime.Now;
+
+            for (int i = 0; i < files.Length; i++)
+            {
+                string fileName = Path.GetFileNameWithoutExtension(files[i]);
+
+                if (string.IsNullOrWhiteSpace(fileName)) continue;
+
+                fileName = fileName.Split("-")[0];
+
+                if (DateTime.TryParseExact(fileName, TimeFormat2, System.Globalization.CultureInfo.InvariantCulture, System.Globalization.DateTimeStyles.None, out DateTime expiryDate))
+                {
+                    if (dateTime.Subtract(expiryDate).Days > MAXRETENTIONDAYS) File.Delete(files[i]);
+                }
+            }
+        }
+
+        /// <summary>
+        /// 创建日志本地文件
+        /// </summary>
+        private void CreateOutlog()
+        {
+            string directory = GetDirectory();
+            string path = directory + "/" + DateTime.Now.ToString(TimeFormat2) + (breakDiskCount > 1 ? "-" + breakDiskCount.ToString() : string.Empty);
+
+            if (!Directory.Exists(directory)) Directory.CreateDirectory(directory);
+
+#if UNITY_STANDALONE || UNITY_EDITOR
+            try
+            {
+                DirectoryInfo dirInfo = new DirectoryInfo(Application.dataPath + "/../" + "Logs/GTrace");
+                dirInfo.Attributes |= FileAttributes.Hidden;
+            }
+            catch (Exception)
+            {
+            }
+#endif
+
+#if !UNITY_EDITOR
+            //非编译器情况下进行日志过期删除逻辑
+            DeleteOldLogFiles();
+#endif
+
+            fileStream = new FileStream(path, FileMode.OpenOrCreate, FileAccess.ReadWrite);
+            streamWriter = new StreamWriter(fileStream);
+            sbuilder = new StringBuilder();
+        }
+
+        /// <summary>
+        /// 释放数据流
+        /// </summary>
+        private void DisposeOutlog()
+        {
+            ManualFlush();
+
+#if !UNITY_EDITOR
+            MemoryStream stream = new MemoryStream();
+            fileStream.Seek(0, SeekOrigin.Begin);
+            fileStream.CopyTo(stream);
+#endif
+
+            streamWriter.Dispose();
+            streamWriter.Close(); ;
+            fileStream.Dispose();
+            fileStream.Close();
+
+#if !UNITY_EDITOR
+            File.Delete(fileStream.Name);
+            fileStream = new FileStream(fileStream.Name+".log", FileMode.Create, FileAccess.Write);
+            CompressStream(stream, fileStream);
+            fileStream.Dispose();
+            fileStream.Close();
+#endif
+        }
+
+        /// <summary>
+        /// 释放所有内容
+        /// </summary>
+        private void DisposeAll()
+        {
+            if (driver != null) GameObject.Destroy(Instance.driver);
+            
+            Application.logMessageReceivedThreaded -= Application_logMessageReceivedThreaded;
+
+            WriteLine($"{nameof(UniLog)} dispose !");
+
+            DisposeOutlog();
+
+            _instance = null;
+
+            UniLogger.Log($"{nameof(UniLog)} dispose !");
+        }
+
+        /// <summary>
+        /// 数据流压缩
+        /// </summary>
+        public void CompressStream(Stream sources, Stream target)
+        {
+            GZipStream compressionStream = new GZipStream(target, CompressionMode.Compress);
+            if (sources.CanSeek) sources.Seek(0, SeekOrigin.Begin);
+            sources.CopyTo(compressionStream);
+            compressionStream.Close();
+        }
+
+        /// <summary>
+        /// 创建日志本地文件分卷
+        /// </summary>
+        private void OutlogBreakDisk()
+        {
+            if (streamWriter.BaseStream.Length < BREAKDISKLENGTH) return;
+
+            breakDiskCount++;
+            DisposeOutlog();
+            CreateOutlog();
+        }
+
+        /// <summary>
+        /// 关闭跟踪日志信息
+        /// </summary>
+        public static void Destroy()
+        {
+            if (!_isInitialize) return;
+
+            _instance.DisposeAll();
+        }
+
+        /// <summary>
+        /// 主动写入日志信息
+        /// </summary>
+        /// <param name="logString">日志信息</param>
+        public static void WriteLine(string logString)
+        {
+            if (_instance != null)
+            {
+                _instance.Application_logMessageReceivedThreaded(logString, string.Empty, LogType.Assert);
+            }
+        }
+
+        /// <summary>
+        /// 读取日志堆栈日志信息并写入本地
+        /// </summary>
+        private void Application_logMessageReceivedThreaded(string logString, string stackTrace, LogType type)
+        {
+            sbuilder.Clear();
+            sbuilder.Append($"[{type.ToString().Substring(0, 3)}]   [{DateTime.Now.ToString(TimeFormat)}]  {logString}");
+
+            StackTrace stack = new StackTrace(true);
+            bool isDebuglog = false;
+
+            for (int i = 0; i < stack.FrameCount; i++)
+            {
+                StackFrame sf = stack.GetFrame(i);
+                if (isDebuglog)
+                {
+                    sbuilder.Append($"    at [{sf.GetMethod().DeclaringType.FullName}:{sf.GetMethod().Name}() Line:{sf.GetFileLineNumber()}]");
+                    break;
+                }
+                else
+                {
+                    string fullName = sf.GetMethod().DeclaringType.FullName;
+
+                    if (fullName.EndsWith("UnityEngine.Debug")) isDebuglog = true;
+                    else if (fullName.EndsWith("UniLog") && sf.GetMethod().Name.Equals("WriteLine")) isDebuglog = true;
+                }
+            }
+
+            streamWriter.WriteLine(sbuilder.ToString());
+
+            _isDirty = true;
+
+            if (!_isManualFlush || !(type == LogType.Assert || type == LogType.Log))
+            {
+                _isDirty = false;
+                streamWriter.Flush();
+            }
+
+            OutlogBreakDisk();
+        }
+
+        /// <summary>
+        /// 主动应用数据流到本地文件
+        /// </summary>
+        public void ManualFlush()
+        {
+            if (!(_isManualFlush && _isDirty)) return;
+
+            _isDirty = false;
+            streamWriter.Flush();
+
+            OutlogBreakDisk();
+        }
+
+    }
+}

--- a/UniFramework/UniLog/Runtime/UniLog.cs.meta
+++ b/UniFramework/UniLog/Runtime/UniLog.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0f42774886e86d041983db9edfb51f44
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UniFramework/UniLog/Runtime/UniLogDriver.cs
+++ b/UniFramework/UniLog/Runtime/UniLogDriver.cs
@@ -1,0 +1,28 @@
+﻿using UnityEngine;
+
+namespace UniFramework.Log {
+
+    /// <summary>
+    /// 当需要手动刷新时可创建此脚本
+    /// </summary>
+    public class UniLogDriver : MonoBehaviour
+    {
+        public static void Initalize() {
+
+            UniLog.Instance.IsManualFlush = true;
+
+            if (UniLog.Instance.driver == null) 
+            {
+                GameObject obj = new UnityEngine.GameObject($"[{nameof(UniLog)}]");
+                obj.AddComponent<UniLogDriver>();
+                UnityEngine.Object.DontDestroyOnLoad(obj);
+                UniLog.Instance.driver = obj;
+            }
+        }
+
+        private void FixedUpdate()
+        {
+            UniLog.Instance.ManualFlush();
+        }
+    }
+}

--- a/UniFramework/UniLog/Runtime/UniLogDriver.cs.meta
+++ b/UniFramework/UniLog/Runtime/UniLogDriver.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 991f56f2c8830904384576b358ca3293
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/UniFramework/UniLog/Runtime/UniLogger.cs
+++ b/UniFramework/UniLog/Runtime/UniLogger.cs
@@ -1,0 +1,21 @@
+﻿using System.Diagnostics;
+
+namespace UniFramework.Log
+{
+    internal static class UniLogger
+    {
+        [Conditional("DEBUG")]
+        public static void Log(string info)
+        {
+            UnityEngine.Debug.Log(info);
+        }
+        public static void Warning(string info)
+        {
+            UnityEngine.Debug.LogWarning(info);
+        }
+        public static void Error(string info)
+        {
+            UnityEngine.Debug.LogError(info);
+        }
+    }
+}

--- a/UniFramework/UniLog/Runtime/UniLogger.cs.meta
+++ b/UniFramework/UniLog/Runtime/UniLogger.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0416d47b3aad4af4eb14845f379050f0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
一个轻量级的日志本地存储，用于自动保存日志信息到本地。

- 日志每行会自动分割为：[type]	[date]	[log]	at [stack]
- stack 信息只输出单行位置，定位于日志输出位置
- 手动执行写入流时，遇到非 *Log*|*Assert* 类型的日志会直接进行流写入，防止崩溃时的数据丢失
- 打包的软件在运行时会自动压缩日志为zip 格式(可用压缩软件打开阅读)，编辑环境不会
- 日志文件将以日期(yyyyMMddHHmmss) 命名进行保存，文件大于 **BREAKDISKLENGTH** 将会自动分卷，每次软件运行将会以新时间点穿件日志文件
- 会自动删除 **MAXRETENTIONDAYS** 天数之外的日志

```
	//使用默认的启动配置(每次Debug.Log 都会执行写入流操作)，开始存储日志
        UniLog.Initalize();
```